### PR TITLE
Mark meew0/dcr as legacy

### DIFF
--- a/catalog/Third-party_APIs.yml
+++ b/catalog/Third-party_APIs.yml
@@ -38,8 +38,9 @@ shards:
   description: A tool that parses Slack slash commands or send incoming web hooks
 - github: discordcr/discordcr
   description: Minimalist Discord library
-- github: meew0/discordcr
-  description: A minimalist Discord API library
+  mirrors: 
+  - github: meew0/discordcr
+    role: legacy
 - github: z64/discordcr
   description: Minimalist Discord library for Crystal
 - github: z64/discordcr-middleware


### PR DESCRIPTION
discordcr was moved to a org that z64 maintains a while back.