### PR TITLE
Add Geode shard

### DIFF
--- a/catalog/Algorithms_and_Data_structures.yml
+++ b/catalog/Algorithms_and_Data_structures.yml
@@ -52,6 +52,11 @@ shards:
   description: Search functionality similar to Sublime Text 2 file searching
 - github: hugopl/fzy
   description: A Crystal port of awesome Fzy project fuzzy finder algorithm
+- gitlab: arctic-fox/geode
+  description: Mathematics library supporting vectors, matrices, quaternions, and
+    more
+  mirrors:
+  - github: icy-arctic-fox/geode
 - github: mettuaditya/graphlb
   description: Collection of graph datastructure and algorithms
 - github: TobiasGSmollett/hash_ring

--- a/catalog/Science_and_Data_analysis.yml
+++ b/catalog/Science_and_Data_analysis.yml
@@ -17,6 +17,7 @@ shards:
   description: Collection of Financial Calculations
 - github: NeuraLegion/fix
   description: Financial Information eXchange library
+- gitlab: arctic-fox/geode
 - github: toddsundsted/ishi
   description: Graph plotting package with a small API and sensible defaults powered
     by gnuplot


### PR DESCRIPTION
Adding the Geode shard which provides a variety of math types and functions.

[GitHub](https://github.com/icy-arctic-fox/geode) and [GitLab](https://gitlab.com/arctic-fox/geode).