### PR TITLE
Add Amazonite

### DIFF
--- a/catalog/Third-party_APIs.yml
+++ b/catalog/Third-party_APIs.yml
@@ -1,6 +1,8 @@
 ---
 name: Third-party APIs
 shards:
+- github: rjnienaber/amazonite
+  description: An unofficial SDK supporting popular AWS APIs
 - github: omarroth/audible.cr
   description: Interface for Audible's internal API
 - github: sdogruyol/aws


### PR DESCRIPTION
This pull request adds [the amazonite shard](https://github.com/rjnienaber/amazonite) to the Third-party APIs catalog.