### PR TITLE
Remove crystalmq

### DIFF
--- a/catalog/Queues_and_Messaging.yml
+++ b/catalog/Queues_and_Messaging.yml
@@ -9,8 +9,6 @@ shards:
   description: AMQP 0.9.1 client with RabbitMQ extensions
 - github: cloudamqp/amqproxy
   description: An intelligent AMQP proxy, with connection and channel pooling/reusing
-- github: crystalmq/crystalmq
-  description: Message Queue similar to NSQ
 - github: bmulvihill/dispatch
   description: In memory asynchronous job processing
 - github: athena-framework/event-dispatcher


### PR DESCRIPTION
Both repo and Github org has disappeared. Googling for `crystal-message-queue` and `crystalmq` doesn't turn anything up that looks like it.
