### PR TITLE
Archive `crystalmq`

### DIFF
--- a/catalog/Queues_and_Messaging.yml
+++ b/catalog/Queues_and_Messaging.yml
@@ -11,6 +11,7 @@ shards:
   description: An intelligent AMQP proxy, with connection and channel pooling/reusing
 - github: crystalmq/crystalmq
   description: Message Queue similar to NSQ
+  state: archived
 - github: bmulvihill/dispatch
   description: In memory asynchronous job processing
 - github: athena-framework/event-dispatcher


### PR DESCRIPTION
> Both repo and Github org has disappeared. Googling for crystal-message-queue and crystalmq doesn't turn anything up that looks like it.

Resolves #89