### PR TITLE
Update mirrors for luce

### DIFF
--- a/catalog/Markdown_Text_Processors.yml
+++ b/catalog/Markdown_Text_Processors.yml
@@ -13,7 +13,9 @@ shards:
 - git: https://codeberg.org/supercell/luce.git
   description: A Markdown library that can parse Markdown (CommonMark/GFM) in to HTML
   mirrors:
+  - git: https://notabug.org/bluemoon/luce.git
   - git: https://pf.osdn.net/gitroot/n/ne/nemophila/luce.git
+    role: legacy
 - github: icyleaf/markd
   description: Yet another markdown parser built for speed, Compliant to CommonMark
     specification


### PR DESCRIPTION
OSDN has been playing up over the last few months, so this just adds a new mirror and marks the OSDN mirror as legacy