### PR TITLE
Temporarily remove athena legacy repo

### DIFF
--- a/catalog/Web_Frameworks.yml
+++ b/catalog/Web_Frameworks.yml
@@ -30,8 +30,6 @@ shards:
 - github: athena-framework/framework
   description: A web framework comprised of reusable, independent components
   mirrors:
-  - github: athena-framework/athena
-    role: legacy
   - github: blacksmoke16/athena
     role: legacy
 - github: ysbaddaden/frost


### PR DESCRIPTION
The catalog importer seems to choke on the transformation for #97. Not sure why. It should be fine with migrating an existing repo to a legacy and adding a new canonical repo.

This patch tries to split this (i.e. replace the canonical) and a follow-up can add the legacy mirror. This should hopefully work out.

Error message:
```
import_shard failed for github:athena-framework/framework (Service::ImportShard::Error)
  from /src/lib/db/src/db/begin_transaction.cr:19:7 in 'perform'
  from /src/lib/shardbox-core/src/service/import_catalog.cr:178:5 in 'import_shard'
  from /src/lib/shardbox-core/src/service/import_catalog.cr:161:5 in 'perform'
  from /src/lib/db/src/db/begin_transaction.cr:33:9 in '__crystal_main'
  from /usr/share/crystal/src/crystal/main.cr:115:5 in 'main'
  from /lib/ld-musl-x86_64.so.1 in '??'
Caused by: new row for relation "shards" violates check constraint "shards_merged_with_archived_at" (PQ::PQError)
  from /src/lib/pg/src/pq/connection.cr:214:22 in 'handle_error'
  from /src/lib/pg/src/pq/connection.cr:196:9 in 'handle_async_frames'
  from /src/lib/pg/src/pq/connection.cr:174:7 in 'read'
  from /src/lib/pg/src/pq/connection.cr:169:7 in 'move_next'
  from /src/lib/db/src/db/result_set.cr:39:13 in 'perform'
  from /src/lib/shardbox-core/src/service/create_shard.cr:17:7 in 'perform'
  from /src/lib/shardbox-core/src/service/import_catalog.cr:178:5 in 'import_shard'
  from /src/lib/shardbox-core/src/service/import_catalog.cr:161:5 in 'perform'
  from /src/lib/db/src/db/begin_transaction.cr:33:9 in '__crystal_main'
  from /usr/share/crystal/src/crystal/main.cr:115:5 in 'main'
  from /lib/ld-musl-x86_64.so.1 in '??'

2024-04-12T16:20:26.894972Z   INFO - shardbox.activity: import_catalog:failed -- repo: "", shard_id: nil, metadata: "{\"exception\":\"PQ::PQError\",\"error_message\":\"current transaction is aborted, commands ignored until end of transaction block\"}"
current transaction is aborted, commands ignored until end of transaction block (PQ::PQError)
  from /src/lib/pg/src/pq/connection.cr:214:22 in 'handle_error'
  from /src/lib/pg/src/pq/connection.cr:196:9 in 'handle_async_frames'
  from /src/lib/pg/src/pq/connection.cr:174:7 in 'read'
  from /src/lib/pg/src/pq/connection.cr:169:7 in 'perform_query'
  from /src/lib/db/src/db/statement.cr:93:9 in 'get_repo?'
  from /src/lib/shardbox-core/src/service/import_catalog.cr:70:12 in 'perform'
  from /src/lib/db/src/db/begin_transaction.cr:33:9 in '__crystal_main'
  from /usr/share/crystal/src/crystal/main.cr:115:5 in 'main'
  from /lib/ld-musl-x86_64.so.1 in '??'
```