### PR TITLE
Add pandocr and command_wrapper shards to catalog

### DIFF
--- a/catalog/CLI_Utils.yml
+++ b/catalog/CLI_Utils.yml
@@ -5,6 +5,8 @@ shards:
   description: ANSI escape codes for manipulating the terminal
 - github: Sija/climate.cr
   description: Tiny tool to make your CLI output coloured
+- git: https://codeberg.org/CampineComputing/command_wrapper.git
+  description: Wrap command-line programs in Crystal
 - github: j8r/cride
   description: A light CLI text editor/IDE
 - github: azukiapp-labs/crystal-chalk-box

--- a/catalog/Markdown_Text_Processors.yml
+++ b/catalog/Markdown_Text_Processors.yml
@@ -19,6 +19,8 @@ shards:
 - github: icyleaf/markd
   description: Yet another markdown parser built for speed, Compliant to CommonMark
     specification
+- git: https://codeberg.org/CampineComputing/pandocr.git
+  description: Pandoc wrapper for Crystal
 - github: huacnlee/remarkdown
   description: extends Markdown lib from Stdlib for Markdown GFM
   state: archived


### PR DESCRIPTION
A couple of weeks ago, I released [pandocr](https://codeberg.org/CampineComputing/pandocr), a Crystal wrapper around the multi-format document converter [pandoc](https://pandoc.org/).

I used [command_wrapper](https://codeberg.org/CampineComputing/command_wrapper) to build pandocr. Command_wrapper is a Crystal library to easily wrap command-line programs in Crystal.