### PR TITLE
Added xxHash shard

### DIFF
--- a/catalog/Algorithms_and_Data_structures.yml
+++ b/catalog/Algorithms_and_Data_structures.yml
@@ -106,5 +106,5 @@ shards:
   description: Ternary Search Tree
 - github: krthr/uuix
   description: A tiny (<1KB) and fast UUID (v4) generator
-- git: git@codeberg.org:Sylphrena/xxHash.cr.git
+- git: https://codeberg.org/Sylphrena/xxHash.cr
   description: Pure crystal implementation of the xxHash algorithms

--- a/catalog/Algorithms_and_Data_structures.yml
+++ b/catalog/Algorithms_and_Data_structures.yml
@@ -106,3 +106,5 @@ shards:
   description: Ternary Search Tree
 - github: krthr/uuix
   description: A tiny (<1KB) and fast UUID (v4) generator
+- git: git@codeberg.org:Sylphrena/xxHash.cr.git
+  description: Pure crystal implementation of the xxHash algorithms


### PR DESCRIPTION
It currently implements `xxHash32` and `xxHash64`. Both `xxHash3` algorithms have no significant upsides for crystal as they rely on SIMD for speed, but I will implement them in the future nonetheless. 
