### PR TITLE
Added ed2k and md4 shard

### DIFF
--- a/catalog/Algorithms_and_Data_structures.yml
+++ b/catalog/Algorithms_and_Data_structures.yml
@@ -48,6 +48,8 @@ shards:
   description: Immutable classes whose main purpose is to hold data
 - github: drujensen/delimiter_tree
   description: A tree structure that is built using a delimiter
+- git: https://codeberg.org/Sylphrena/Ed2k.cr
+  description: A pure crystal implementation of the ed2k (and MD4) hash algorithms for file hashing.
 - github: tcrouch/edits.cr
   description: Collection of edit distance algorithms
 - github: acoustep/fuzzy_match.cr


### PR DESCRIPTION
The shard is fully functional from an `ed2k` hash perspective. `MD4` should not be used on it's own, as it was written with `ed2k` in mind, and is not convenient to use. 