### PR TITLE
Added Win32cr in C bindings

### DIFF
--- a/catalog/C_bindings.yml
+++ b/catalog/C_bindings.yml
@@ -88,6 +88,8 @@ shards:
   description: Bindings for the libjpeg-turbo (turpojpeg C API)
 - github: naqvis/wasmer-crystal
   description: Bindings for the `wasmer` WebAssembly runtime
+- github: mjblack/win32cr
+  description: Bindings for Windows API
 - github: TamasSzekeres/x11-cr
   description: X11 bindings
 - github: woodruffw/x_do.cr


### PR DESCRIPTION
Win32cr is a C bindings for the Win32 API that is built upon the Win32 metadata export.
